### PR TITLE
Fix held game keys in BlockRelease mode; add WoW profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project are documented in this file.
 
+## [3.0.1] - 2026-06-19
+
+### Added
+- **Bundled `WoW.json` profile** for World of Warcraft, tuned for both AZERTY and
+  QWERTY layouts: `BlockRelease` mode with a tight 12 ms per-key release on the
+  movement keys (Z/Q and W/A plus shared S/D), Space (jump), left Shift, and right
+  Ctrl, so held and rapidly tapped game keys stay responsive. Pop-ups and mouse
+  debouncing are off. Appears as **WoW** in the Profile tray submenu.
+
+### Fixed
+- **Held game keys broke in `BlockRelease` mode.** The deferred key-up was re-emitted
+  by virtual key with scan code 0, so games reading input by hardware scan code
+  (DirectInput / Raw Input, including World of Warcraft) never saw a clean release and
+  the key desynced in-game (e.g. Space or AZERTY Z stopped working). The synthetic
+  key-up is now sent by scan code (`KEYEVENTF_SCANCODE`), captured from the original
+  key-down and preserving the extended-key flag, so it is indistinguishable from a real
+  hardware release. Falls back to `MapVirtualKey` if the captured scan code is 0.
+
 ## [3.0.0] - 2026-06-17
 
 ### Added

--- a/KeyboardRepeatFilter.csproj
+++ b/KeyboardRepeatFilter.csproj
@@ -9,7 +9,7 @@
     <Description>G915-Stutter-Fix</Description>
     <Copyright>MIT License</Copyright>
     <RepositoryUrl>https://github.com/lucduguaysita/G915-Stutter-Fix</RepositoryUrl>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <Title>G915-Stutter-Fix</Title>
     <AssemblyTitle>G915-Stutter-Fix</AssemblyTitle>
     <ApplicationIcon>app.ico</ApplicationIcon>
@@ -65,6 +65,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>gaming.json</Link>
     </None>
+    <None Update="src\WoW.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>WoW.json</Link>
+    </None>
   </ItemGroup>
   <!-- Copy KeyboardHeatmap.exe next to the app's build output (Debug and
        Release) so "Generate report" works when running/testing from VS. -->
@@ -84,6 +88,7 @@
     <Copy SourceFiles="$(TargetDir)Newtonsoft.Json.dll" DestinationFolder="$(ReleasesDir)" Condition="Exists('$(TargetDir)Newtonsoft.Json.dll')" />
     <Copy SourceFiles="$(TargetDir)config.json" DestinationFolder="$(ReleasesDir)" Condition="Exists('$(TargetDir)config.json')" />
     <Copy SourceFiles="$(TargetDir)gaming.json" DestinationFolder="$(ReleasesDir)" Condition="Exists('$(TargetDir)gaming.json')" />
+    <Copy SourceFiles="$(TargetDir)WoW.json" DestinationFolder="$(ReleasesDir)" Condition="Exists('$(TargetDir)WoW.json')" />
     <Copy SourceFiles="$(MSBuildProjectDirectory)\KeyboardHeatmap\bin\Release\KeyboardHeatmap.exe" DestinationFolder="$(ReleasesDir)" Condition="Exists('$(MSBuildProjectDirectory)\KeyboardHeatmap\bin\Release\KeyboardHeatmap.exe')" />
   </Target>
 </Project>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ No drivers. No firmware flashing. No registry surgery. No network access. Close 
 system is exactly as it was. User reports confirm it eliminates the stutter/double-keypress problem
 on affected G915/G915X units, and it's small enough to read end-to-end in a coffee break.
 
-> **Version 3.0.0**, Windows 10/11 x64 · .NET Framework 4.8 · MIT licensed · 100% offline
+> **Version 3.0.1**, Windows 10/11 x64 · .NET Framework 4.8 · MIT licensed · 100% offline
 
 ---
 
@@ -23,6 +23,23 @@ on affected G915/G915X units, and it's small enough to read end-to-end in a coff
 |---|---|
 | `KeyboardRepeatFilter.exe` | Runs in the system tray and silently filters stutter/duplicate keypresses (and, optionally, chattering mouse clicks) in real time. |
 | `KeyboardHeatmap.exe` | Companion CLI that reads the filter log and generates a self-contained HTML heatmap of filtered key counts, great for *seeing* which keys misbehave. |
+
+---
+
+## What's new in 3.0.1
+
+- **Held game keys fixed in *Protect held keys* mode.** This mode re-emits a withheld key-up
+  itself, but it sent the release by virtual key with no scan code. Games that read the keyboard by
+  hardware scan code (DirectInput/Raw Input, **World of Warcraft** included) never saw a clean
+  release, so a key like **Space** (jump) or **Z** on an AZERTY layout would desync and stop working.
+  The synthetic release is now sent by scan code, captured from the real key-down and keeping the
+  extended-key flag, so games treat it exactly like a physical key-up.
+- **Bundled `WoW.json` profile.** A ready-made World of Warcraft profile that works on both **AZERTY
+  and QWERTY** layouts: *Protect held keys* mode with a tight 12 ms release on the movement keys
+  (**Z/Q** and **W/A** plus shared **S/D**), **Space**, left **Shift**, and right **Ctrl**. Switch to
+  it live from **Tray → Profile → WoW**.
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the complete list.
 
 ---
 

--- a/src/KeyboardHookFilter.cs
+++ b/src/KeyboardHookFilter.cs
@@ -26,6 +26,14 @@ namespace KeyboardRepeatFilter
         private const uint InputKeyboard = 1;
         private const uint KeyeventfExtendedkey = 0x0001;
         private const uint KeyeventfKeyup = 0x0002;
+        // Re-emit the deferred key-up by scan code, not virtual key. Games (and
+        // anything reading via DirectInput / Raw Input) match key-ups to key-downs
+        // by hardware scan code; a VK-only synthetic up carries scan code 0 and is
+        // ignored by them, leaving the key logically stuck in-game.
+        private const uint KeyeventfScancode = 0x0008;
+        // MapVirtualKey translation: virtual key -> scan code. Used as a fallback
+        // when the captured hardware scan code is unexpectedly 0.
+        private const uint MapvkVkToVsc = 0;
 
         // Marker stamped into dwExtraInfo on key-ups we inject ourselves, so the
         // hook can recognise and ignore its own synthetic events ("RFLT").
@@ -49,6 +57,7 @@ namespace KeyboardRepeatFilter
         private readonly object _sync = new object();
         private readonly bool[] _pendingUp = new bool[256];
         private readonly bool[] _pendingExtended = new bool[256];
+        private readonly uint[] _pendingScan = new uint[256];
         private readonly int[] _thresholdMsByVk = new int[256];
         private readonly Timer[] _releaseTimers = new Timer[256];
         private bool _blockRelease;
@@ -241,7 +250,7 @@ namespace KeyboardRepeatFilter
                 if (vk >= 0 && vk < 256 && !_excludedKeys[vk])
                 {
                     bool filter = _blockRelease
-                        ? HandleBlockRelease(vk, message, kb.flags)
+                        ? HandleBlockRelease(vk, message, kb.flags, kb.scanCode)
                         : HandleBlockRepress(vk, message);
 
                     if (filter)
@@ -301,7 +310,7 @@ namespace KeyboardRepeatFilter
         // key-down follows within the threshold, drop both so the key stays
         // logically held; otherwise a timer re-emits the genuine key-up.
         // Returns true when the event should be swallowed.
-        private bool HandleBlockRelease(int vk, int message, uint flags)
+        private bool HandleBlockRelease(int vk, int message, uint flags, uint scanCode)
         {
             lock (_sync)
             {
@@ -342,6 +351,7 @@ namespace KeyboardRepeatFilter
                     // follows within the threshold.
                     _pendingUp[vk] = true;
                     _pendingExtended[vk] = (flags & LlkhfExtended) != 0;
+                    _pendingScan[vk] = scanCode;
                     EnsureTimer(vk).Change(_thresholdMsByVk[vk], Timeout.Infinite);
                     return true;
                 }
@@ -370,6 +380,7 @@ namespace KeyboardRepeatFilter
         {
             var vk = (int)state;
             bool extended;
+            uint scanCode;
 
             lock (_sync)
             {
@@ -382,14 +393,28 @@ namespace KeyboardRepeatFilter
                 _pendingUp[vk] = false;
                 _isPressed[vk] = false;
                 extended = _pendingExtended[vk];
+                scanCode = _pendingScan[vk];
             }
 
             // No bounce arrived within the window: emit the genuine key-up now.
-            InjectKeyUp(vk, extended);
+            InjectKeyUp(vk, extended, scanCode);
         }
 
-        private void InjectKeyUp(int vk, bool extended)
+        private void InjectKeyUp(int vk, bool extended, uint scanCode)
         {
+            // Re-emit the release by hardware scan code so scan-code readers
+            // (DirectInput / Raw Input, used by most games) match it to their
+            // key-down. Fall back to mapping the VK if the captured scan code is
+            // unexpectedly 0. The extended-key bit must accompany the scan code so
+            // keys such as right Ctrl/Alt and the arrow cluster release correctly.
+            ushort scan = (ushort)scanCode;
+            if (scan == 0)
+            {
+                scan = (ushort)MapVirtualKey((uint)vk, MapvkVkToVsc);
+            }
+
+            uint flags = KeyeventfKeyup | KeyeventfScancode | (extended ? KeyeventfExtendedkey : 0u);
+
             var input = new Input
             {
                 type = InputKeyboard,
@@ -397,9 +422,9 @@ namespace KeyboardRepeatFilter
                 {
                     ki = new KeybdInput
                     {
-                        wVk = (ushort)vk,
-                        wScan = 0,
-                        dwFlags = KeyeventfKeyup | (extended ? KeyeventfExtendedkey : 0u),
+                        wVk = 0,
+                        wScan = scan,
+                        dwFlags = flags,
                         time = 0,
                         dwExtraInfo = (IntPtr)InjectedMarkerValue
                     }
@@ -545,5 +570,8 @@ namespace KeyboardRepeatFilter
 
         [DllImport("user32.dll", SetLastError = true)]
         private static extern uint SendInput(uint nInputs, Input[] pInputs, int cbSize);
+
+        [DllImport("user32.dll")]
+        private static extern uint MapVirtualKey(uint uCode, uint uMapType);
     }
 }

--- a/src/WoW.json
+++ b/src/WoW.json
@@ -1,0 +1,27 @@
+{
+  "LogLevel": "Info",
+  "LogFilePath": "C:/Temp/KeyboardRepeatFilter.log",
+  "HeatmapDays": "all",
+  "FilterMode": "BlockRelease",
+  "ShowElevatedWindowNotice": false,
+  "RunAsAdmin": false,
+  "MinRepeatIntervalMs": 28.0,
+  "ExcludedKeys": [
+    "Back",
+    "Return"
+  ],
+  "PerKeyMinRepeatIntervalMs": {
+    "Z": 12.0,
+    "Q": 12.0,
+    "S": 12.0,
+    "D": 12.0,
+    "W": 12.0,
+    "A": 12.0,
+    "Space": 12.0,
+    "LSHIFT": 12.0,
+    "RCONTROL": 12.0
+  },
+  "FilterMouseButtons": false,
+  "MouseMinRepeatIntervalMs": 50.0,
+  "ExcludedMouseButtons": []
+}


### PR DESCRIPTION
## Summary

Fixes "Protect held keys" (`BlockRelease`) mode breaking held/tapped keys in games, and adds a dedicated World of Warcraft profile.

### The bug
`BlockRelease` mode withholds a key-up and later re-emits it itself via `SendInput`. It sent the release by **virtual key with scan code 0**. Games read the keyboard by **hardware scan code** (DirectInput / Raw Input, World of Warcraft included), so they never saw a clean release: keys like **Space** (jump) or **Z** on an AZERTY layout desynced and stopped working in-game. `BlockRepress` mode was unaffected because it only swallows events and never synthesizes input.

### The fix
The synthetic key-up is now sent **by scan code** (`KEYEVENTF_SCANCODE`), captured from the original key-down and preserving the extended-key flag, so it is indistinguishable from a physical hardware release. Falls back to `MapVirtualKey` if the captured scan code is ever 0. The `"RFLT"` `dwExtraInfo` marker is retained so the hook still passes through its own re-injected releases.

### Also included
- **Bundled `WoW.json` profile** tuned for both **AZERTY and QWERTY** layouts: `BlockRelease` mode with a tight 12 ms per-key release on movement keys (**Z/Q** and **W/A** plus shared **S/D**), **Space**, left **Shift**, and right **Ctrl**. Wired into the build copy steps so it ships next to the app and appears as **WoW** under Tray -> Profile.
- Version bumped to **3.0.1** with matching `CHANGELOG.md` and `README.md` ("What's new in 3.0.1") notes.

## Testing
- Release build is clean (0 warnings, 0 errors).
- `WoW.json` confirmed copied to both `bin/Release/net48/` and `releases/`.
- Profile token names verified against the `VirtualKeys` resource (`VK_SPACE`, `VK_LSHIFT`, `VK_RCONTROL`).
- No automated tests exist for the low-level hook (live OS hook); in-game verification of Space/Z release is recommended before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
