### PR TITLE
v3.1.0: startup profile, CapsLock fix, update check, YubiKey burst bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project are documented in this file.
 
+## [3.1.0] - 2026-06-23
+
+### Added
+- **Startup profile, set from the tray.** Selecting a profile in **Tray → Profile** now also makes it
+  the startup default: the choice is saved to `config.json` (`"DefaultProfile"`), so the next launch,
+  including Windows sign-in via Autostart, comes up on that profile instead of `config.json`. The
+  profile's filter mode and `RunAsAdmin` take effect from launch. The profile checkmark marks both the
+  active and the startup profile; selecting **(default) config** clears the default. A saved profile
+  that later goes missing is logged and falls back to `config.json`. Backed by a new `DefaultProfile`
+  config field (also editable by hand).
+
+- **Burst bypass for hardware tokens (`BurstBypass`, opt-in, off by default).** A security key that
+  types a one-time password (a YubiKey tap or hold) sends characters at machine speed, and repeated
+  characters in the code (such as two `u`s) were being dropped as stutters, breaking authentication.
+  Setting `"BurstBypass": true` in `config.json` makes the filter recognise a sustained burst of
+  key-downs far faster than any human can type and suspend filtering for its duration, so repeats
+  pass through. There is no tray toggle: a normal keyboard never reaches the burst threshold, so with
+  the flag off (the default) behaviour is unchanged. A duplicate in the first one or two characters of
+  a code can still rarely be dropped; tapping the token again generates a fresh code.
+- **Update check.** On startup the app makes a single best-effort request to the GitHub releases
+  API to see whether a newer version is published. If one is, users who have nag popups enabled get
+  a brief toast (click it to open the releases page); users who disabled nag popups are not toasted.
+  Either way, the **About** box notes when a newer version is available and its Yes button then opens
+  the releases page. No data is sent, nothing is downloaded or installed, and any failure (offline,
+  rate limit, etc.) is silent: the app is fully usable without the check.
+
+### Fixed
+- **CapsLock could desync.** CapsLock is a toggle key, so a swallowed or deferred event (which both
+  filter modes can produce) could leave the OS toggle state and the keyboard LED inverted until the
+  app was restarted. CapsLock is now always excluded from filtering, in every mode, with no config
+  switch.
+
 ## [3.0.2] - 2026-06-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ All notable changes to this project are documented in this file.
   a brief toast (click it to open the releases page); users who disabled nag popups are not toasted.
   Either way, the **About** box notes when a newer version is available and its Yes button then opens
   the releases page. No data is sent, nothing is downloaded or installed, and any failure (offline,
-  rate limit, etc.) is silent: the app is fully usable without the check.
+  rate limit, etc.) is silent: the app is fully usable without the check. This is the only outbound
+  network access the app makes; set `"CheckForUpdates": false` in `config.json` to keep it fully
+  offline (the check is skipped and the About box reports it as disabled).
 
 ### Fixed
 - **CapsLock could desync.** CapsLock is a toggle key, so a swallowed or deferred event (which both

--- a/KeyboardRepeatFilter.csproj
+++ b/KeyboardRepeatFilter.csproj
@@ -12,7 +12,7 @@
     <!-- Single source of truth for the version: AssemblyVersion, FileVersion, and
          InformationalVersion are generated from this by the SDK (GenerateAssemblyInfo,
          default on), so bumping it here flows to the built exe automatically. -->
-    <Version>3.0.2</Version>
+    <Version>3.1.0</Version>
     <Title>G915-Stutter-Fix</Title>
     <AssemblyTitle>G915-Stutter-Fix</AssemblyTitle>
     <ApplicationIcon>app.ico</ApplicationIcon>

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ mid-shortcut, a game character that won't keep walking. `G915-Stutter-Fix` sits 
 system tray, watches the keyboard at the lowest user-mode level Windows allows, and silently drops
 those invalid events *before* they ever reach your applications.
 
-No drivers. No firmware flashing. No registry surgery. No network access. Close the app and your
-system is exactly as it was. User reports confirm it eliminates the stutter/double-keypress problem
-on affected G915/G915X units, and it's small enough to read end-to-end in a coffee break.
+No drivers. No firmware flashing. No registry surgery. The only thing it ever sends over the network
+is an optional version check at startup, which you can disable to keep it fully offline. Close the
+app and your system is exactly as it was. User reports confirm it eliminates the stutter/double-keypress
+problem on affected G915/G915X units, and it's small enough to read end-to-end in a coffee break.
 
-> **Version 3.0.2**, Windows 10/11 x64 · .NET Framework 4.8 · MIT licensed · 100% offline
+> **Version 3.1.0**, Windows 10/11 x64 · .NET Framework 4.8 · MIT licensed · offline (optional startup version check, can be disabled)
 
 ---
 
@@ -23,6 +24,28 @@ on affected G915/G915X units, and it's small enough to read end-to-end in a coff
 |---|---|
 | `KeyboardRepeatFilter.exe` | Runs in the system tray and silently filters stutter/duplicate keypresses (and, optionally, chattering mouse clicks) in real time. |
 | `KeyboardHeatmap.exe` | Companion CLI that reads the filter log and generates a self-contained HTML heatmap of filtered key counts, great for *seeing* which keys misbehave. |
+
+---
+
+## What's new in 3.1.0
+
+- **Boot straight into a profile.** Selecting a profile from **Tray → Profile** now also makes it
+  your startup profile: it is remembered in `config.json` (`DefaultProfile`) and loaded on every
+  launch, including at Windows sign-in via **Autostart**. Pick **(default) config** to clear it.
+- **CapsLock is never filtered.** As a toggle key, a swallowed CapsLock event could leave its state
+  and indicator light out of sync (and need a restart to recover). It is now always excluded in every
+  mode, with nothing to configure, so that can't happen.
+- **Startup update check.** The app makes one best-effort request to the GitHub releases API to see
+  whether a newer version exists. With notifications on you get a toast; the **About** box always
+  shows the status (latest, newer available, could not check) and never blocks on the network. No data
+  is sent and nothing is downloaded. Set `"CheckForUpdates": false` to stay fully offline.
+- **Hardware-token support (`BurstBypass`, opt-in).** A security key like a **YubiKey** "types" a
+  one-time password at machine speed, and repeated characters in it (such as two `u`s) were being
+  dropped as stutters, breaking sign-in. Enable `"BurstBypass": true` and the filter recognises the
+  machine-speed burst and steps aside for its duration. Off by default; a normal keyboard never trips
+  it.
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the complete list.
 
 ---
 
@@ -133,7 +156,8 @@ See [`CHANGELOG.md`](CHANGELOG.md) for the complete list.
 A low-level keyboard hook (`WH_KEYBOARD_LL`) inspects every key event and discards repeats that
 arrive faster than a configurable threshold (default **28 ms**, below the biomechanical limit of a
 real double-tap). Filtering is per-key configurable and certain keys (Backspace, Enter, volume) are
-excluded by default so legitimate fast input is never touched.
+excluded by default so legitimate fast input is never touched. **CapsLock is always excluded** in
+every mode, since dropping one of its events could desync the toggle and its indicator light.
 
 ### Two filter modes
 - **Block double presses** (`BlockRepress`, default), blocks the spurious *re-press*, so one tap
@@ -161,9 +185,12 @@ buttons, and is **off by default** so keyboard-only users are unaffected. Turn i
 ### Profiles (with a ready-made Gaming profile)
 Keep more than one configuration side by side. Drop any number of config `.json` files next to the
 app and switch between them live from **Tray → Profile**. Every file that looks like a config (it
-shares our setting names) appears as a selectable profile; the startup `config.json` is marked
+shares our setting names) appears as a selectable profile; the base `config.json` is marked
 **(default)**. Selecting one loads it as the live configuration and applies it instantly, great for
-keeping, say, a precise everyday-typing setup and an aggressive gaming setup a click apart.
+keeping, say, a precise everyday-typing setup and an aggressive gaming setup a click apart. Selecting
+a profile also makes it your **startup profile** (saved to `config.json` as `DefaultProfile`), so the
+app comes back up on it next time, including at Windows sign-in; pick **(default) config** to clear
+that and start on the base config again.
 
 A **`gaming.json`** profile ships in the box, tuned for movement:
 
@@ -190,6 +217,24 @@ Windows security (UIPI) prevents a normal-user hook from filtering input to **ad
 windows. The app detects this state, turns the tray icon **yellow** with a plain-language tooltip,
 shows a brief focus-safe corner notice (toggleable), and records it in the log, recovering
 automatically when a normal window regains focus.
+
+### Hardware-token support
+A security key that "types" a one-time password (a **YubiKey** tap or hold) sends its characters at
+machine speed, and those codes often contain repeated characters that the filter can mistake for a
+stutter and drop, breaking authentication. Set `"BurstBypass": true` in `config.json` and the filter
+recognises a sustained burst of keystrokes far faster than a human can type and steps aside for its
+duration, so every character (repeats included) passes through. It is **off by default** with no tray
+toggle, since a normal keyboard never reaches the burst threshold. See
+[Hardware tokens](docs/USAGE.md#hardware-tokens-yubikey-and-similar) for the one edge case it cannot
+fully cover.
+
+### Update checking
+On startup the app makes a single best-effort request to the GitHub releases API to see whether a
+newer version is out. If one is, and notifications are on, a brief toast points you to the release
+page; the **About** box always reports the status (latest, newer available, could not check, or
+disabled) and only reads the cached result, so it opens instantly and never waits on the network. No
+data is sent and nothing is downloaded or installed. This is the only outbound network access the app
+makes, and `"CheckForUpdates": false` turns it off so the app stays **100% offline**.
 
 ### Diagnostic heatmap
 `KeyboardHeatmap.exe` turns your filter log into a beautiful, self-contained HTML report so you can
@@ -237,7 +282,7 @@ success, `KeyboardHeatmap.exe` opens it for you automatically.
 1. Build the solution in `Release` mode (or download a release).
 2. Open the `releases` folder after the build completes.
 3. Ensure it contains `KeyboardRepeatFilter.exe`, `KeyboardHeatmap.exe`, `Newtonsoft.Json.dll`,
-   `config.json`, and the bundled `gaming.json` profile.
+   `config.json`, and the bundled `gaming.json` and `WoW.json` profiles.
 4. Copy those files to a writable folder of your choice (for example `C:\Utils\KeyboardRepeatFilter`).
 5. Run `KeyboardRepeatFilter.exe`.
 6. Confirm the tray icon appears and type normally, the stutter should be gone.
@@ -261,8 +306,9 @@ indicates the app is unsafe.
 
 To run it: on the **UAC** prompt click **Yes**; on the **SmartScreen** prompt click **More info**,
 then **Run anyway**. If you'd rather verify before trusting it, the complete C# source is in the
-`src` folder, the app makes no network access, and you can build the executables yourself from
-source (see [Build Environment](#build-environment)).
+`src` folder, the only network access is an optional version check you can disable
+(`"CheckForUpdates": false`), and you can build the executables yourself from source (see
+[Build Environment](#build-environment)).
 
 #### Antivirus false positives
 
@@ -312,12 +358,15 @@ Everything is controlled by `config.json` next to the executable. Full reference
 |---|---|---|
 | `LogLevel` | `Info` | `Trace` logs every filtered key (needed for the heatmap). |
 | `LogFilePath` | `C:/Temp/KeyboardRepeatFilter.log` | Where the log is written. |
+| `DefaultProfile` | _(none)_ | Profile to load automatically at startup; normally set for you by selecting one in **Tray → Profile**. |
 | `HeatmapDays` | `all` | Heatmap window: `all`, or a number of days back from now to chart (older entries skipped). |
 | `FilterMode` | `BlockRepress` | `BlockRepress` (stop double presses) or `BlockRelease` (protect held keys). |
 | `ShowElevatedWindowNotice` | `true` | Show the brief popup when an admin window is focused. |
 | `RunAsAdmin` | `false` | Relaunch elevated on every launch (UAC prompt each time). Toggle from the tray. |
 | `MinRepeatIntervalMs` | `28.0` | Repeats faster than this are treated as stutter. |
-| `ExcludedKeys` | `["Back", "Return"]` | Keys never filtered, by name or number. |
+| `BurstBypass` | `false` | Opt-in: step aside during machine-speed input bursts so hardware tokens (YubiKey) keep repeated characters. |
+| `CheckForUpdates` | `true` | One startup version check against GitHub; set `false` to stay fully offline. |
+| `ExcludedKeys` | `["Back", "Return"]` | Keys never filtered, by name or number (CapsLock is always excluded). |
 | `PerKeyMinRepeatIntervalMs` | `{}` | Per-key threshold overrides, by name or number. |
 | `FilterMouseButtons` | `false` | Enable debouncing of chattering mouse buttons. |
 | `MouseMinRepeatIntervalMs` | `50.0` | Mouse clicks faster than this are treated as chatter. |

--- a/config.template.json
+++ b/config.template.json
@@ -1,11 +1,13 @@
 {
   "LogLevel": "Trace",
   "LogFilePath": "C:/Temp/KeyboardRepeatFilter.log",
+  "DefaultProfile": "",
   "HeatmapDays": "all",
   "FilterMode": "BlockRepress",
   "ShowElevatedWindowNotice": true,
   "RunAsAdmin": false,
   "MinRepeatIntervalMs": 28.0,
+  "BurstBypass": false,
   "FilterMouseButtons": false,
   "MouseMinRepeatIntervalMs": 50.0,
   "ExcludedMouseButtons": [],

--- a/config.template.json
+++ b/config.template.json
@@ -8,6 +8,7 @@
   "RunAsAdmin": false,
   "MinRepeatIntervalMs": 28.0,
   "BurstBypass": false,
+  "CheckForUpdates": true,
   "FilterMouseButtons": false,
   "MouseMinRepeatIntervalMs": 50.0,
   "ExcludedMouseButtons": [],

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -43,6 +43,7 @@ Your `releases` folder should contain:
 | `RunAsAdmin` | `false` | When `true`, the app relaunches itself elevated on every launch if not already elevated (a UAC prompt appears each time). Toggle from the tray menu. |
 | `MinRepeatIntervalMs` | `28.0` | Repeats faster than this many milliseconds are treated as stutter. |
 | `BurstBypass` | `false` | Opt-in. When `true`, the filter detects machine-speed input (a hardware token such as a YubiKey typing a one-time password) and suspends filtering for that burst, so repeated characters are not dropped. Leave `false` unless you authenticate with such a device; a normal keyboard never reaches the burst threshold. There is no tray toggle, set it here. |
+| `CheckForUpdates` | `true` | When `true`, the app makes one best-effort request to the GitHub releases API at startup to see whether a newer version exists (no data sent, nothing downloaded). Set to `false` to keep the app fully offline; this is the only network access it ever makes. |
 | `ExcludedKeys` | `["Back", "Return"]` | Keys that are never filtered. Names or numeric codes (see below). **CapsLock is always excluded** regardless of this list, so its toggle state can never desync. |
 | `ExcludedVkCodes` | _(none)_ | Legacy numeric-only form of `ExcludedKeys`; still honored and merged. |
 | `PerKeyMinRepeatIntervalMs` | `{}` | Per-key threshold overrides, keyed by key name or numeric code. |
@@ -214,6 +215,10 @@ appears; click it to open the releases page, or just let it dismiss. If you disa
 toast appears, but the **About** box still tells you a newer version is available. The check sends no
 data, never downloads or installs anything, and fails silently (offline, rate-limited, etc.), so the
 app works exactly the same with no network access.
+
+This is the only outbound network access the app makes. To keep it fully offline, set
+`"CheckForUpdates": false` in `config.json`: the check is skipped entirely and the About box reports
+it as disabled.
 
 Every toggle persists to `config.json`, so the menu and the file never disagree.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -36,12 +36,14 @@ Your `releases` folder should contain:
 |---|---|---|
 | `LogLevel` | `Info` | Set to `Trace` to log every filtered event to `LogFilePath`. |
 | `LogFilePath` | `C:/Temp/KeyboardRepeatFilter.log` | Where the filter/lifecycle log is written. |
+| `DefaultProfile` | _(none)_ | Profile file name loaded automatically at startup (with or without `.json`). Normally set for you by selecting a profile in the tray **Profile** menu; empty starts on `config.json`. |
 | `HeatmapDays` | `all` | Heatmap time window: `all` charts the whole log; a positive number charts only entries from that many days back from when the heatmap is run. |
 | `FilterMode` | `BlockRepress` | Master switch for how a stutter is filtered (see below). |
 | `ShowElevatedWindowNotice` | `true` | Show a brief corner popup when focus moves to an admin window (where filtering is inactive). Set `false` to suppress only the popup; the tray icon still turns yellow and the event is still logged. |
 | `RunAsAdmin` | `false` | When `true`, the app relaunches itself elevated on every launch if not already elevated (a UAC prompt appears each time). Toggle from the tray menu. |
 | `MinRepeatIntervalMs` | `28.0` | Repeats faster than this many milliseconds are treated as stutter. |
-| `ExcludedKeys` | `["Back", "Return"]` | Keys that are never filtered. Names or numeric codes (see below). |
+| `BurstBypass` | `false` | Opt-in. When `true`, the filter detects machine-speed input (a hardware token such as a YubiKey typing a one-time password) and suspends filtering for that burst, so repeated characters are not dropped. Leave `false` unless you authenticate with such a device; a normal keyboard never reaches the burst threshold. There is no tray toggle, set it here. |
+| `ExcludedKeys` | `["Back", "Return"]` | Keys that are never filtered. Names or numeric codes (see below). **CapsLock is always excluded** regardless of this list, so its toggle state can never desync. |
 | `ExcludedVkCodes` | _(none)_ | Legacy numeric-only form of `ExcludedKeys`; still honored and merged. |
 | `PerKeyMinRepeatIntervalMs` | `{}` | Per-key threshold overrides, keyed by key name or numeric code. |
 | `FilterMouseButtons` | `false` | Master switch for mouse-button debouncing (see below). |
@@ -111,6 +113,22 @@ the left, right, middle, and both side (X1/X2) buttons.
 > **Note:** like the keyboard hook, the mouse hook is bypassed for windows running as administrator
 > (UIPI) unless the app itself is elevated.
 
+## Hardware tokens (YubiKey and similar)
+
+A security key that "types" a one-time password (a YubiKey tap or hold) sends its characters at
+machine speed, far faster than human typing. Because those codes often contain repeated characters
+(for example two `u`s in a row), the filter can mistake the repeat for a stutter and drop it,
+corrupting the code so authentication fails. If you use such a device, set `"BurstBypass": true` in
+`config.json`. The filter then notices the machine-speed burst and stops filtering for its duration,
+so every character (repeats included) passes through. It is off by default and there is no tray
+toggle, since a normal keyboard never reaches the burst threshold.
+
+One honest limit: the bypass needs a couple of keystrokes to confirm a burst, so a duplicate in the
+very first one or two characters of a code can still be dropped on rare occasions. Because tokens
+generate a fresh code on every tap, simply tapping again resolves it. A guaranteed, per-device fix
+would require identifying the token as a distinct input device, which is a larger change not yet
+implemented.
+
 ## Gaming and anti-cheat
 
 For games, use the **Protect held keys** filter mode (`"FilterMode": "BlockRelease"`). It is the only
@@ -168,17 +186,34 @@ Right-click the tray icon for these options:
   least two of our setting names). Selecting one loads it as the live configuration and applies it
   immediately; a checkmark shows the active one. To add a profile, drop another config file (e.g.
   `gaming.json`) in the app folder and restart. While a profile is active, the other tray toggles
-  save back into **that** file. The active choice is per-session: on the next launch the app starts
-  from `config.json` again.
+  save back into **that** file. **Selecting a profile also makes it the startup default**: the choice
+  is written to `config.json` (as `"DefaultProfile"`), so the next launch, including Windows sign-in via
+  **Autostart**, comes up on that profile, with its filter mode and even `RunAsAdmin` in effect from the
+  start. The checkmark therefore marks both the active profile and the one that loads at startup. Select
+  **(default) config** to clear the startup default and go back to starting on `config.json`. If a saved
+  default profile file later goes missing, the app logs it and falls back to `config.json`.
 - **Disable nag popups**: when checked, suppresses the brief popup shown when an administrator
-  window is focused (equivalent to `"ShowElevatedWindowNotice": false`). The tray icon and log are
-  unaffected.
+  window is focused (equivalent to `"ShowElevatedWindowNotice": false`). It also suppresses the
+  "newer version available" toast (see below). The tray icon and log are unaffected.
 - **Autostart**: launch automatically when you sign in.
 - **Heatmap → Generate report / Generate report (verbose)**: runs `KeyboardHeatmap.exe`
   against your current log and opens the HTML report; the verbose option adds the daily-activity
   chart. If no log exists yet, a message explains how to enable logging.
-- **About…**: version and project information.
+- **About…**: version and project information, plus a line reporting the update status: "You are
+  running the latest version", "A newer version (vX.Y.Z) is available", "Could not check for updates"
+  (offline), or "Checking for updates..." if the startup check has not finished yet. It only reads the
+  cached result, so it opens instantly and never waits on the network. When a newer release is
+  available the Yes button opens the GitHub releases page; otherwise it opens the project page.
 - **Exit**: stop filtering and close the app.
+
+### Update check
+
+On startup the app makes a single best-effort request to the GitHub releases API to see whether a
+newer version has been published. If one has, and you have **not** disabled nag popups, a brief toast
+appears; click it to open the releases page, or just let it dismiss. If you disabled nag popups, no
+toast appears, but the **About** box still tells you a newer version is available. The check sends no
+data, never downloads or installs anything, and fails silently (offline, rate-limited, etc.), so the
+app works exactly the same with no network access.
 
 Every toggle persists to `config.json`, so the menu and the file never disagree.
 

--- a/src/FilterConfig.cs
+++ b/src/FilterConfig.cs
@@ -7,6 +7,16 @@ namespace KeyboardRepeatFilter
         public string LogLevel { get; set; } = "Info";
         public string LogFilePath { get; set; } = "C:\\Temp\\KeyboardRepeatFilter.log";
 
+        // Optional profile to load automatically at startup instead of staying on
+        // config.json. The value is a profile file name in the application folder,
+        // with or without the ".json" extension, e.g. "WoW" or "WoW.json". When set
+        // and the file exists, the app boots straight into that profile (its tray
+        // toggles, filter mode, and RunAsAdmin all take effect from launch); later
+        // tray edits save back into the activated profile, not config.json. Empty or
+        // missing means start on config.json as before. Only read from config.json;
+        // it is not chained from within an activated profile.
+        public string DefaultProfile { get; set; }
+
         // Heatmap time window. "all" (default) charts the entire log; otherwise a
         // positive number of days, counted back from the moment the heatmap is run,
         // so older log entries are skipped. Read by KeyboardHeatmap; the main app
@@ -38,6 +48,18 @@ namespace KeyboardRepeatFilter
         public bool RunAsAdmin { get; set; } = false;
 
         public double MinRepeatIntervalMs { get; set; } = 28.0;
+
+        // Opt-in safeguard for hardware tokens that "type" at machine speed, such as
+        // a YubiKey emitting a one-time password. Those devices send dozens of real
+        // key events only milliseconds apart, so any repeated character (common in
+        // YubiKey modhex OTPs, e.g. "uu") looks exactly like a stutter, gets dropped,
+        // and the code fails to authenticate. When true, the filter recognises a
+        // sustained burst of key-downs far faster than a human can type and suspends
+        // filtering for its duration so the repeats pass through. Off by default and
+        // exposed only in config (no tray item): a normal keyboard never reaches the
+        // burst threshold, so leaving it off preserves the original behaviour exactly,
+        // and only the rare user who types secrets with such a device needs it.
+        public bool BurstBypass { get; set; } = false;
 
         // Master switch for mouse-button debouncing. When true, a separate
         // low-level mouse hook drops a button-down that arrives within

--- a/src/FilterConfig.cs
+++ b/src/FilterConfig.cs
@@ -61,6 +61,13 @@ namespace KeyboardRepeatFilter
         // and only the rare user who types secrets with such a device needs it.
         public bool BurstBypass { get; set; } = false;
 
+        // When true (default), the app makes a single best-effort request to the
+        // GitHub releases API at startup to see whether a newer version exists (no
+        // data is sent, nothing is downloaded). Set to false to keep the app fully
+        // offline: the check is skipped entirely and the About box reports it as
+        // disabled. The only outbound network access the app ever makes is this check.
+        public bool CheckForUpdates { get; set; } = true;
+
         // Master switch for mouse-button debouncing. When true, a separate
         // low-level mouse hook drops a button-down that arrives within
         // MouseMinRepeatIntervalMs of that button's previous button-up, which

--- a/src/KeyboardHookFilter.cs
+++ b/src/KeyboardHookFilter.cs
@@ -18,6 +18,13 @@ namespace KeyboardRepeatFilter
         private const int WmSysKeyUp = 0x0105;
         private const uint WmQuit = 0x0012;
 
+        // CapsLock virtual-key code. CapsLock is a toggle key: withholding or
+        // swallowing one of its events (which either filter mode can do) leaves the
+        // OS toggle state and the keyboard LED out of sync until the app restarts.
+        // It is never a key you "repeat", so we exclude it from filtering outright,
+        // unconditionally and with no config switch.
+        private const int VkCapital = 0x14;
+
         // Low-level keyboard hook flag: the key is an extended key (right Ctrl/Alt,
         // arrows, etc.). Preserved when we re-inject a deferred key-up.
         private const uint LlkhfExtended = 0x01;
@@ -34,6 +41,15 @@ namespace KeyboardRepeatFilter
         // hook can recognise and ignore its own synthetic events ("RFLT").
         private const long InjectedMarkerValue = 0x52464C54;
         private static readonly UIntPtr InjectedMarker = (UIntPtr)InjectedMarkerValue;
+
+        // Burst-bypass tuning (only consulted when FilterConfig.BurstBypass is on). A
+        // gap shorter than this between consecutive key-downs of any key counts as
+        // machine-speed; this many such gaps in a row switches the bypass on. Three
+        // keys inside ~50ms (two sub-25ms gaps) is roughly 3600 WPM, far beyond any
+        // human yet comfortably slower than a hardware token, so a normal keyboard
+        // never trips it while a YubiKey engages it within the first few characters.
+        private const double BurstGapMs = 25.0;
+        private const int BurstMinStreak = 2;
 
         private readonly FilterConfig _config;
         private readonly long[] _lastUpTicks = new long[256];
@@ -57,6 +73,15 @@ namespace KeyboardRepeatFilter
         private readonly Timer[] _releaseTimers = new Timer[256];
         private bool _blockRelease;
 
+        // Burst-bypass state (opt-in). While a machine-speed stream of key-downs is in
+        // progress, filtering is suspended so a hardware token's repeated characters
+        // are not dropped. All inert when _burstBypass is false.
+        private bool _burstBypass;
+        private long _burstGapTicks;
+        private long _lastDownTicks;
+        private int _rapidStreak;
+        private bool _inBurst;
+
         private Thread _messageThread;
         private HookProcDelegate _hookProc;
         private IntPtr _hookId = IntPtr.Zero;
@@ -71,6 +96,12 @@ namespace KeyboardRepeatFilter
         public void Start()
         {
             _blockRelease = string.Equals(_config.FilterMode, "BlockRelease", StringComparison.OrdinalIgnoreCase);
+
+            _burstBypass = _config.BurstBypass;
+            _burstGapTicks = (long)(Stopwatch.Frequency * BurstGapMs / 1000.0);
+            _lastDownTicks = 0;
+            _rapidStreak = 0;
+            _inBurst = false;
 
             var defaultThresholdTicks = Stopwatch.Frequency * _config.MinRepeatIntervalMs / 1000.0;
             var defaultThresholdMs = Math.Max(1, (int)Math.Ceiling(_config.MinRepeatIntervalMs));
@@ -144,6 +175,10 @@ namespace KeyboardRepeatFilter
                     }
                 }
             }
+
+            // CapsLock is always excluded, regardless of config, so its toggle
+            // state can never be desynced by a swallowed or deferred event.
+            _excludedKeys[VkCapital] = true;
 
             if (unresolved.Count > 0)
             {
@@ -242,21 +277,68 @@ namespace KeyboardRepeatFilter
                     return CallNextHookEx(_hookId, nCode, wParam, lParam);
                 }
 
-                if (vk >= 0 && vk < 256 && !_excludedKeys[vk])
+                if (vk >= 0 && vk < 256)
                 {
-                    bool filter = _blockRelease
-                        ? HandleBlockRelease(vk, message, kb.flags, kb.scanCode)
-                        : HandleBlockRepress(vk, message);
-
-                    if (filter)
+                    // Track input rate first (across all keys, even excluded ones) so
+                    // the burst decision reflects the real device speed.
+                    if (_burstBypass)
                     {
-                        return new IntPtr(1);
+                        UpdateBurstState(message);
+                    }
+
+                    if (!_excludedKeys[vk])
+                    {
+                        bool filter = _blockRelease
+                            ? HandleBlockRelease(vk, message, kb.flags, kb.scanCode)
+                            : HandleBlockRepress(vk, message);
+
+                        if (filter)
+                        {
+                            return new IntPtr(1);
+                        }
                     }
                 }
             }
 
             return CallNextHookEx(_hookId, nCode, wParam, lParam);
         }
+
+        // Recognises machine-speed input (hardware tokens such as a YubiKey) by the
+        // rate of incoming key-downs. _inBurst is set while keystrokes arrive far
+        // faster than a human can type and cleared as soon as the pace drops back to
+        // human speed. Only called when burst bypass is enabled.
+        private void UpdateBurstState(int message)
+        {
+            if (message != WmKeyDown && message != WmSysKeyDown)
+            {
+                return;
+            }
+
+            long now = Stopwatch.GetTimestamp();
+            long gap = now - _lastDownTicks;
+
+            // A single fast gap is exactly what a lone stutter looks like, so the
+            // streak must build over several consecutive fast gaps before we treat
+            // the stream as a machine burst; one slow gap ends it.
+            if (_lastDownTicks != 0 && gap < _burstGapTicks)
+            {
+                if (_rapidStreak < BurstMinStreak)
+                {
+                    _rapidStreak++;
+                }
+            }
+            else
+            {
+                _rapidStreak = 0;
+            }
+
+            _lastDownTicks = now;
+            _inBurst = _rapidStreak >= BurstMinStreak;
+        }
+
+        // True while an opt-in burst bypass is active: filtering is suspended so a
+        // hardware token's repeated characters are not dropped.
+        private bool BurstActive() => _burstBypass && _inBurst;
 
         // Original behaviour: let the spurious key-up through and block the
         // duplicate key-down that follows it within the threshold.
@@ -267,7 +349,7 @@ namespace KeyboardRepeatFilter
 
             if (message == WmKeyDown || message == WmSysKeyDown)
             {
-                if (!_isPressed[vk] && (now - _lastUpTicks[vk]) < _thresholdTicksByVk[vk])
+                if (!_isPressed[vk] && (now - _lastUpTicks[vk]) < _thresholdTicksByVk[vk] && !BurstActive())
                 {
                     LogFiltered(vk, "filtered");
                     // Bounce key-down: swallow it, and remember to swallow the
@@ -277,6 +359,8 @@ namespace KeyboardRepeatFilter
                     return true;
                 }
 
+                // Either a genuine press, or a fast repeat during a machine-speed
+                // burst that we deliberately let through: record it as pressed.
                 _isPressed[vk] = true;
                 // A genuine press cancels any pending up-swallow so its own release
                 // is never mistaken for a bounce key-up.
@@ -309,6 +393,24 @@ namespace KeyboardRepeatFilter
         {
             lock (_sync)
             {
+                if (BurstActive())
+                {
+                    // Machine-speed burst (e.g. a hardware token): defer and swallow
+                    // nothing so every character, repeats included, passes through.
+                    if (message == WmKeyDown || message == WmSysKeyDown)
+                    {
+                        if (_pendingUp[vk]) CancelPendingUp(vk);
+                        _isPressed[vk] = true;
+                    }
+                    else if (message == WmKeyUp || message == WmSysKeyUp)
+                    {
+                        if (_pendingUp[vk]) CancelPendingUp(vk);
+                        _isPressed[vk] = false;
+                    }
+
+                    return false;
+                }
+
                 if (message == WmKeyDown || message == WmSysKeyDown)
                 {
                     if (_pendingUp[vk])

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -35,6 +35,18 @@ namespace KeyboardRepeatFilter
         private static uint _lastToastPid;
         private static ToastForm _toast;
 
+        // Result of the startup update check, set on a background thread and read on
+        // the UI thread (volatile so the read sees the write). Null until the check
+        // finishes; afterwards it carries an explicit status (up to date, newer
+        // available, or could-not-check). _updateCheckComplete flips true once the
+        // background check finishes, whatever the outcome. The UI only ever reads
+        // these cached fields, so it never blocks on the network, even in an airtight
+        // (offline) environment where the check runs until its timeout.
+        private static volatile UpdateChecker.Result _updateResult;
+        private static volatile bool _updateCheckComplete;
+        private static bool _updateToastShown;
+        private static System.Windows.Forms.Timer _updateToastTimer;
+
         private const string TooltipNormal = "Keyboard Repeat Filter";
         private const string TooltipBypassed = "Keyboard Repeat Filter - paused for this admin window";
 
@@ -73,6 +85,12 @@ namespace KeyboardRepeatFilter
             _config = LoadConfig();
             _activeConfigPath = ConfigFilePath;
             _startedAtUtc = DateTime.UtcNow;
+
+            // Honor a configured default profile before anything observes the config:
+            // this runs ahead of the elevation check and the hook creation so the
+            // profile's RunAsAdmin and filter settings take effect from launch, and
+            // the tray menu builds against the profile that is actually live.
+            ApplyDefaultProfileAtStartup();
             RegisterGlobalExceptionHandlers();
             Application.ApplicationExit += (_, __) => LogShutdown("ApplicationExit");
 
@@ -202,7 +220,8 @@ namespace KeyboardRepeatFilter
             foreach (var pf in FindProfileFiles())
             {
                 string filePath = pf.Path;
-                // config.json is the startup default; flag it so in the menu.
+                // config.json is the base config; selecting it clears any startup
+                // default. Flag it in the menu so that role is clear.
                 string displayName = PathsEqual(filePath, ConfigFilePath) ? "(default) " + pf.Name : pf.Name;
                 var item = new MenuItem(displayName) { RadioCheck = true, Checked = PathsEqual(filePath, _activeConfigPath) };
                 item.Click += (s, e) =>
@@ -211,6 +230,12 @@ namespace KeyboardRepeatFilter
 
                     foreach (var mi in profileItems) mi.Checked = false;
                     item.Checked = true;
+
+                    // Selecting a profile also makes it the startup default: record it
+                    // in config.json so the next launch (including Windows sign-in via
+                    // Autostart) comes up on it. Selecting config.json clears the
+                    // default so the app starts on config.json again.
+                    PersistDefaultProfile(PathsEqual(filePath, ConfigFilePath) ? null : Path.GetFileName(filePath));
 
                     // Reflect the freshly loaded settings in the other toggles.
                     bool rel = string.Equals(_config.FilterMode, "BlockRelease", StringComparison.OrdinalIgnoreCase);
@@ -258,6 +283,8 @@ namespace KeyboardRepeatFilter
             _bypassTimer.Tick += (_, __) => UpdateBypassIndicator();
             _bypassTimer.Start();
             UpdateBypassIndicator();
+
+            StartUpdateCheck();
 
             Application.Run();
 
@@ -336,6 +363,7 @@ namespace KeyboardRepeatFilter
             // over without tripping the "already running" guard.
             LogLifecycle("Elevating", "relaunching with administrator rights at user request");
             _bypassTimer?.Stop();
+            _updateToastTimer?.Stop();
             try { _toast?.Close(); } catch { /* ignore */ }
             _notifyIcon.Visible = false;
             _filter?.Stop();
@@ -348,6 +376,7 @@ namespace KeyboardRepeatFilter
         private static void OnExit(object sender, EventArgs e)
         {
             _bypassTimer?.Stop();
+            _updateToastTimer?.Stop();
             try { _toast?.Close(); } catch { /* ignore */ }
             _notifyIcon.Visible = false;
             _filter.Stop();
@@ -493,6 +522,99 @@ namespace KeyboardRepeatFilter
             _toast.Show(); // non-activating; does not take focus
         }
 
+        // Starts the best-effort "newer version available" check. The network call
+        // runs on a background thread so it never delays the tray icon or blocks the
+        // UI; a short UI timer then surfaces the result (a toast) once it completes.
+        private static void StartUpdateCheck()
+        {
+            var current = Assembly.GetExecutingAssembly().GetName().Version;
+
+            var thread = new Thread(() =>
+            {
+                var result = UpdateChecker.CheckForNewer(current);
+                _updateResult = result;
+                _updateCheckComplete = true;
+                if (result.Status == UpdateChecker.Status.UpdateAvailable)
+                {
+                    LogLifecycle("UpdateAvailable", $"latest={result.Tag}, current={current}");
+                }
+            })
+            {
+                IsBackground = true,
+                Name = "KeyboardRepeatFilter.UpdateCheck"
+            };
+            thread.Start();
+
+            // Poll the result on the UI thread, then stop. Polling a volatile flag
+            // keeps the check entirely off the UI thread with no cross-thread UI
+            // marshalling, matching how _bypassTimer already drives tray updates.
+            _updateToastTimer = new System.Windows.Forms.Timer { Interval = 1000 };
+            _updateToastTimer.Tick += (_, __) =>
+            {
+                if (!_updateCheckComplete)
+                {
+                    return;
+                }
+
+                _updateToastTimer.Stop();
+                MaybeShowUpdateToast();
+            };
+            _updateToastTimer.Start();
+        }
+
+        // Shows a one-time toast when a newer release was found, but only for users
+        // who have not disabled nag popups. Those who have stay undisturbed; the
+        // About box still tells them a new version is available.
+        private static void MaybeShowUpdateToast()
+        {
+            var update = _updateResult;
+            if (update == null || update.Status != UpdateChecker.Status.UpdateAvailable || _updateToastShown)
+            {
+                return;
+            }
+
+            if (_config != null && !_config.ShowElevatedWindowNotice)
+            {
+                return; // "do not nag" is set: no toast; the About box carries the news.
+            }
+
+            _updateToastShown = true;
+
+            try { _toast?.Close(); }
+            catch { /* a previous toast may already be gone */ }
+
+            _toast = new ToastForm(
+                "Keyboard Repeat Filter",
+                $"A newer version ({update.Tag}) is available. Click to open the releases page.",
+                10000,
+                () => OpenUrl(update.Url));
+            _toast.FormClosed += (_, __) =>
+            {
+                _toast?.Dispose();
+                _toast = null;
+            };
+            _toast.Show(); // non-activating; does not take focus
+        }
+
+        // Opens a URL in the default browser, staying resilient if the shell launch
+        // is unavailable (the tray app must never crash on a failed launch).
+        private static void OpenUrl(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                return;
+            }
+
+            try
+            {
+                Process.Start(new ProcessStartInfo { FileName = url, UseShellExecute = true });
+            }
+            catch
+            {
+                // Keep tray app resilient if shell launch is unavailable.
+            }
+        }
+
         // Builds a yellow-tinted copy of the tray icon used to flag the bypass
         // state. The tint keeps the icon's shape (transparency is preserved) while
         // shifting its colours toward amber.
@@ -600,13 +722,43 @@ namespace KeyboardRepeatFilter
             var version = assembly.GetName().Version?.ToString() ?? "unknown";
             var repoUrl = "https://github.com/lucduguaysita/G915-Stutter-Fix";
 
+            // Reflect the startup update check here for everyone, including users who
+            // disabled the toast. This only reads the cached result, so it never waits
+            // on the network: if the background check has not finished (or is still
+            // timing out in an airtight environment), it simply says so.
+            var update = _updateResult;
+            string updateLine;
+            string targetUrl = repoUrl;
+
+            if (!_updateCheckComplete || update == null)
+            {
+                updateLine = "Checking for updates...\r\n\r\n";
+            }
+            else if (update.Status == UpdateChecker.Status.UpdateAvailable)
+            {
+                updateLine = $"A newer version ({update.Tag}) is available.\r\n\r\n";
+                targetUrl = update.Url;
+            }
+            else if (update.Status == UpdateChecker.Status.UpToDate)
+            {
+                updateLine = "You are running the latest version.\r\n\r\n";
+            }
+            else
+            {
+                updateLine = "Could not check for updates (no connection?).\r\n\r\n";
+            }
+
+            bool updateAvailable = update != null && update.Status == UpdateChecker.Status.UpdateAvailable;
+            string prompt = updateAvailable ? "Open the GitHub releases page?" : "Open the GitHub project page?";
+
             var aboutText =
                 "G915 Stutter Fix\r\n" +
                 $"Version: {version}\r\n\r\n" +
+                updateLine +
                 "User-mode keyboard event filter for invalid HID repeats.\r\n\r\n" +
                 $"Project: {repoUrl}\r\n" +
                 "License: MIT\r\n\r\n" +
-                "Open the GitHub project page?";
+                prompt;
 
             var result = MessageBox.Show(
                 aboutText,
@@ -616,18 +768,7 @@ namespace KeyboardRepeatFilter
 
             if (result == DialogResult.Yes)
             {
-                try
-                {
-                    Process.Start(new ProcessStartInfo
-                    {
-                        FileName = repoUrl,
-                        UseShellExecute = true
-                    });
-                }
-                catch
-                {
-                    // Keep tray app resilient if shell launch is unavailable.
-                }
+                OpenUrl(targetUrl);
             }
         }
 
@@ -713,6 +854,123 @@ namespace KeyboardRepeatFilter
                 // Consider adding logging here for diagnostics.
                 return new FilterConfig();
             }
+        }
+
+        // Records which profile should load at startup by writing DefaultProfile
+        // into config.json. It always targets config.json, because that is the only
+        // file consulted for the startup default at launch. Pass a profile file name
+        // to set it, or null to clear it so the app starts on config.json again.
+        private static void PersistDefaultProfile(string profileFileName)
+        {
+            string value = string.IsNullOrWhiteSpace(profileFileName) ? null : profileFileName;
+
+            // When config.json is itself the active save target, fold the change into
+            // the normal save so the in-memory config and the file stay in step (a
+            // later SaveConfig would otherwise rewrite config.json from _config and
+            // clobber a direct edit here).
+            if (PathsEqual(_activeConfigPath, ConfigFilePath))
+            {
+                _config.DefaultProfile = value;
+                SaveConfig();
+                LogLifecycle("DefaultProfileSaved", value ?? "cleared (start on config.json)");
+                return;
+            }
+
+            // A profile is active, so config.json is not the save target. Edit only
+            // its DefaultProfile on disk, preserving config.json's own settings and
+            // leaving the active profile file untouched.
+            try
+            {
+                var path = ConfigFilePath;
+                var obj = File.Exists(path)
+                    ? JToken.Parse(File.ReadAllText(path)) as JObject ?? new JObject()
+                    : new JObject();
+
+                if (value == null)
+                {
+                    obj.Remove("DefaultProfile");
+                }
+                else
+                {
+                    obj["DefaultProfile"] = value;
+                }
+
+                File.WriteAllText(path, obj.ToString(Formatting.Indented));
+                LogLifecycle("DefaultProfileSaved", value ?? "cleared (start on config.json)");
+            }
+            catch (Exception ex)
+            {
+                LogLifecycle("DefaultProfileSaveError", ex.Message);
+            }
+        }
+
+        // Loads the profile named in config.json's DefaultProfile (if any) as the
+        // live configuration at startup, so the app comes up on that profile instead
+        // of config.json. No-op when DefaultProfile is unset, points back at
+        // config.json, or names a file that is missing/unreadable; in those cases the
+        // app stays on the already-loaded config.json. Runs before the hook is
+        // created, so no filter restart is needed here.
+        private static void ApplyDefaultProfileAtStartup()
+        {
+            var name = _config?.DefaultProfile;
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return;
+            }
+
+            string path = ResolveProfilePath(name);
+            if (path == null)
+            {
+                LogLifecycle("DefaultProfileMissing", $"DefaultProfile='{name}' was not found; staying on config.json");
+                return;
+            }
+
+            if (PathsEqual(path, ConfigFilePath))
+            {
+                return; // DefaultProfile points at config.json: nothing to switch.
+            }
+
+            try
+            {
+                var cfg = JsonConvert.DeserializeObject<FilterConfig>(File.ReadAllText(path));
+                if (cfg == null)
+                {
+                    LogLifecycle("DefaultProfileLoadError", $"file={Path.GetFileName(path)} deserialized to null; staying on config.json");
+                    return;
+                }
+
+                _config = cfg;
+                _activeConfigPath = path;
+                LogLifecycle("DefaultProfileActivated", $"file={Path.GetFileName(path)}");
+            }
+            catch (Exception ex)
+            {
+                LogLifecycle("DefaultProfileLoadError", $"file={Path.GetFileName(path)}, {ex.Message}; staying on config.json");
+            }
+        }
+
+        // Resolves a DefaultProfile value to a full path in the app folder, accepting
+        // the name with or without the ".json" extension (e.g. "WoW" or "WoW.json").
+        // Returns null when no matching file exists.
+        private static string ResolveProfilePath(string name)
+        {
+            var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+            string direct = Path.Combine(baseDir, name);
+            if (File.Exists(direct))
+            {
+                return direct;
+            }
+
+            if (!name.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            {
+                string withExt = Path.Combine(baseDir, name + ".json");
+                if (File.Exists(withExt))
+                {
+                    return withExt;
+                }
+            }
+
+            return null;
         }
 
         // Property names that identify a KeyboardRepeatFilter config file. A *.json

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -527,6 +527,12 @@ namespace KeyboardRepeatFilter
         // UI; a short UI timer then surfaces the result (a toast) once it completes.
         private static void StartUpdateCheck()
         {
+            if (_config != null && !_config.CheckForUpdates)
+            {
+                // Fully offline by choice: skip the only network call the app makes.
+                return;
+            }
+
             var current = Assembly.GetExecutingAssembly().GetName().Version;
 
             var thread = new Thread(() =>
@@ -730,7 +736,11 @@ namespace KeyboardRepeatFilter
             string updateLine;
             string targetUrl = repoUrl;
 
-            if (!_updateCheckComplete || update == null)
+            if (_config != null && !_config.CheckForUpdates)
+            {
+                updateLine = "Update check is disabled.\r\n\r\n";
+            }
+            else if (!_updateCheckComplete || update == null)
             {
                 updateLine = "Checking for updates...\r\n\r\n";
             }

--- a/src/UpdateChecker.cs
+++ b/src/UpdateChecker.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Net;
+using Newtonsoft.Json.Linq;
+
+namespace KeyboardRepeatFilter
+{
+    /// <summary>
+    /// Best-effort check for a newer GitHub release. Every failure mode (no
+    /// network, rate limit, timeout, malformed JSON, unparseable tag) is treated
+    /// the same as "no update available" and never surfaces to the user: the app
+    /// is fully usable offline, so a missed check must be silent.
+    /// </summary>
+    internal static class UpdateChecker
+    {
+        // The "latest release" endpoint returns the most recent non-prerelease,
+        // non-draft release for the repository.
+        private const string LatestReleaseApi =
+            "https://api.github.com/repos/lucduguaysita/G915-Stutter-Fix/releases/latest";
+
+        // Human-facing page used as a fallback link and from the About box.
+        public const string ReleasesPageUrl =
+            "https://github.com/lucduguaysita/G915-Stutter-Fix/releases/latest";
+
+        // Hard cap on the whole request. WebClient's default is ~100s; a check that
+        // cannot answer in a few seconds is abandoned so the background thread never
+        // lingers. A timeout is just another silent "no update".
+        private const int RequestTimeoutMs = 8000;
+
+        // Outcome of a check. Failed covers every error path (offline, timeout, rate
+        // limit, malformed response): the network answer is simply unknown.
+        public enum Status { Failed, UpToDate, UpdateAvailable }
+
+        public sealed class Result
+        {
+            public Status Status { get; set; }
+            public Version Latest { get; set; } // normalised Major.Minor.Build (when known)
+            public string Tag { get; set; }     // raw tag, e.g. "v3.2.0" (when known)
+            public string Url { get; set; }     // release page to open (when newer)
+        }
+
+        /// <summary>
+        /// Queries the latest GitHub release and reports whether it is newer than
+        /// <paramref name="current"/>. Always returns a Result; its Status is Failed
+        /// when the check could not be completed. Blocking; call from a background
+        /// thread.
+        /// </summary>
+        public static Result CheckForNewer(Version current)
+        {
+            if (current == null)
+            {
+                return new Result { Status = Status.Failed };
+            }
+
+            try
+            {
+                // GitHub's API is HTTPS-only and rejects older TLS; make sure 1.2 is
+                // permitted without disturbing whatever the OS already enabled.
+                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
+                string json;
+                using (var client = new TimedWebClient(RequestTimeoutMs))
+                {
+                    // GitHub returns 403 to requests without a User-Agent.
+                    client.Headers[HttpRequestHeader.UserAgent] = "KeyboardRepeatFilter-update-check";
+                    client.Headers[HttpRequestHeader.Accept] = "application/vnd.github+json";
+                    json = client.DownloadString(LatestReleaseApi);
+                }
+
+                var obj = JObject.Parse(json);
+                string tag = (string)obj["tag_name"];
+                if (!TryParseVersion(tag, out Version latest))
+                {
+                    return new Result { Status = Status.Failed };
+                }
+
+                if (latest > Normalize(current))
+                {
+                    string url = (string)obj["html_url"];
+                    return new Result
+                    {
+                        Status = Status.UpdateAvailable,
+                        Latest = latest,
+                        Tag = tag,
+                        Url = string.IsNullOrWhiteSpace(url) ? ReleasesPageUrl : url
+                    };
+                }
+
+                return new Result { Status = Status.UpToDate, Latest = latest, Tag = tag };
+            }
+            catch
+            {
+                return new Result { Status = Status.Failed }; // best-effort: unknown
+            }
+        }
+
+        // Parses a release tag such as "v3.2.0" or "3.2" into a normalised version.
+        private static bool TryParseVersion(string tag, out Version version)
+        {
+            version = null;
+            if (string.IsNullOrWhiteSpace(tag))
+            {
+                return false;
+            }
+
+            string s = tag.Trim();
+            if (s.StartsWith("v", StringComparison.OrdinalIgnoreCase))
+            {
+                s = s.Substring(1);
+            }
+
+            if (!Version.TryParse(s, out Version parsed))
+            {
+                return false;
+            }
+
+            version = Normalize(parsed);
+            return true;
+        }
+
+        // Collapses a version to Major.Minor.Build with absent components treated as
+        // 0, so the 3-part release tags ("3.1.0") compare cleanly against the 4-part
+        // assembly version ("3.1.0.0") without the unspecified-component (-1) skew.
+        private static Version Normalize(Version v) =>
+            new Version(Math.Max(0, v.Major), Math.Max(0, v.Minor), Math.Max(0, v.Build));
+
+        // WebClient does not expose a timeout, so set one on the underlying request.
+        // Bounds the whole check; on expiry DownloadString throws and the caller's
+        // catch turns it into a silent "no update".
+        private sealed class TimedWebClient : WebClient
+        {
+            private readonly int _timeoutMs;
+
+            public TimedWebClient(int timeoutMs)
+            {
+                _timeoutMs = timeoutMs;
+            }
+
+            protected override WebRequest GetWebRequest(Uri address)
+            {
+                var request = base.GetWebRequest(address);
+                if (request != null)
+                {
+                    request.Timeout = _timeoutMs;
+                    if (request is HttpWebRequest http)
+                    {
+                        http.ReadWriteTimeout = _timeoutMs;
+                    }
+                }
+
+                return request;
+            }
+        }
+    }
+}

--- a/src/config.json
+++ b/src/config.json
@@ -1,11 +1,13 @@
 {
   "LogLevel": "Trace",
   "LogFilePath": "C:/Temp/KeyboardRepeatFilter.log",
+  "DefaultProfile": "",
   "HeatmapDays": "all",
   "FilterMode": "BlockRepress",
   "ShowElevatedWindowNotice": true,
   "RunAsAdmin": false,
   "MinRepeatIntervalMs": 28.0,
+  "BurstBypass": false,
   "FilterMouseButtons": false,
   "MouseMinRepeatIntervalMs": 50.0,
   "ExcludedMouseButtons": [],

--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
   "RunAsAdmin": false,
   "MinRepeatIntervalMs": 28.0,
   "BurstBypass": false,
+  "CheckForUpdates": true,
   "FilterMouseButtons": false,
   "MouseMinRepeatIntervalMs": 50.0,
   "ExcludedMouseButtons": [],


### PR DESCRIPTION
## Summary

Version 3.1.0: four user-facing improvements plus a fix to keep the app's offline promise accurate.

- **Startup profile (`DefaultProfile`).** Selecting a profile in **Tray → Profile** now also records it in `config.json`, so the app boots into that profile on every launch (including Windows sign-in via Autostart). Selecting **(default) config** clears it. The active-profile checkmark doubles as the startup marker.
- **CapsLock always excluded.** As a toggle key, a swallowed CapsLock event could leave its state and indicator light out of sync until a restart. It is now never filtered, in any mode, with nothing to configure. Fixes the reported stuck-CapsLock bug.
- **Startup update check.** One best-effort request to the GitHub releases API on a background thread (8s timeout, silent on any failure). A toast appears for users who keep nag popups on; the **About** box always shows an explicit status (latest / newer available / could not check / checking / disabled) and only reads cached state, so it never blocks on the network, even offline.
- **Hardware-token support (`BurstBypass`, opt-in, off by default).** A YubiKey "types" a one-time password at machine speed, and repeated characters in it (e.g. two `u`s) were being dropped as stutters, breaking MFA. When enabled, the filter recognises a sustained machine-speed burst and steps aside for its duration so repeats pass through. A normal keyboard never reaches the threshold, and with the flag off the behaviour is byte-for-byte unchanged.
- **`CheckForUpdates` toggle (default true).** The update check made the README's "100% offline" / "no network access" claims untrue. This flag turns the check off entirely (About box then reports it disabled), restoring a genuine fully-offline mode. The README and docs were corrected to match.

## Behaviour safety

- All new behaviour is gated: `BurstBypass` and the update check default to inert/off-impact paths, so existing users see no change unless they opt in.
- The burst detector triggers only on sustained sub-25ms inter-key gaps (roughly 3600 WPM), which human typing and gaming cannot reach. Known limit: a duplicate in the first one or two characters of a token code can still rarely be dropped (documented).

## Docs

`README.md` (badge, "What's new in 3.1.0", feature sections, config table, offline/trust wording), `docs/USAGE.md`, `CHANGELOG.md`, `config.template.json`, and `config.json` all updated. Version bumped to 3.1.0.

## Notes

- `releases/` build artifacts (rebuilt exe, an old release zip, generated config) were intentionally left out of this PR; they belong to the release process, not source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
